### PR TITLE
Use correct `_pack_message` function name

### DIFF
--- a/humaneval_eval.py
+++ b/humaneval_eval.py
@@ -85,7 +85,7 @@ class HumanEval(Eval):
 
         def fn(sample: dict[str, str]):
             prompt_messages = [
-                sampler._pack_mesage(role="user", content=instruction + sample["prompt"])
+                sampler._pack_message(role="user", content=instruction + sample["prompt"])
             ]
             completions = [
                 find_code(sampler(prompt_messages)) for _ in range(self._num_samples_per_task)


### PR DESCRIPTION
There is a small typo in `human_eval.py` where a non-existent method named `_pack_mesage` is called. This PR uses the correct function name.