### PR TITLE
Update SimpleQAEval to use direct CSV URL instead of blobfile

### DIFF
--- a/simpleqa_eval.py
+++ b/simpleqa_eval.py
@@ -6,7 +6,6 @@ SimpleQA: Measuring short-form factuality in large language models
 
 import random 
 import re
-import blobfile as bf
 import pandas
 from . import common
 from .types import Eval, EvalResult, SamplerBase, SingleEvalResult
@@ -100,9 +99,7 @@ CHOICE_LETTER_TO_STRING = dict(zip(CHOICE_LETTERS, CHOICE_STRINGS))
 class SimpleQAEval(Eval):
     def __init__(self, grader_model: SamplerBase, num_examples: int | None = None, n_repeats: int = 1):
         df = pandas.read_csv(
-            bf.BlobFile(
-                f"az://openaipublic/simple-evals/simple_qa_test_set.csv"
-            )
+            "https://openaipublic.blob.core.windows.net/simple-evals/simple_qa_test_set.csv"
         )
         examples = [row.to_dict() for _, row in df.iterrows()]
         if num_examples:


### PR DESCRIPTION
Update SimpleQAEval to use direct CSV URL instead of blobfile

Changes made:
- Replace Azure blob storage path (az://) with direct HTTPS URL for accessing the SimpleQA dataset
- Remove blobfile dependency as it's no longer needed
- Use pandas.read_csv() to directly fetch the dataset

The modified URL will be:
`https://openaipublic.blob.core.windows.net/simple-evals/simple_qa_test_set.csv`

This change simplifies the data loading process and removes the need for Azure blob storage authentication.

Related to issue: #25 