### PR TITLE
Fix MMLU answer extraction regex for repeated "Answer: LETTER" pattern

### DIFF
--- a/common.py
+++ b/common.py
@@ -23,7 +23,7 @@ D) {D}
 ANSWER_PATTERN_MULTICHOICE = r"(?i)Answer\s*:\s*([A-D])"
 ANSWER_PATTERN = r"(?i)Answer\s*:\s*([^\n]+)"
 MULTILINGUAL_ANSWER_PATTERN_TEMPLATE = (
-    "(?i){}\s*([A-D]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])"
+    "(?i)(?=(?:{}\s*([A-D]|[أ-د]|[অ]|[ব]|[ড]|[ঢ]|[Ａ]|[Ｂ]|[Ｃ]|[Ｄ])))"
 )
 # All the different ways "Answer" is written in different languages
 MULTILINGUAL_ANSWER_REGEXES = [

--- a/mmlu_eval.py
+++ b/mmlu_eval.py
@@ -105,9 +105,10 @@ class MMLUEval(Eval):
             extracted_answer = None
             for answer_regex in MULTILINGUAL_ANSWER_REGEXES:
                 regex = MULTILINGUAL_ANSWER_PATTERN_TEMPLATE.format(answer_regex)
-                match = re.search(regex, response_text)
-                if match:
-                    extracted_answer = normalize_extracted_answer(match.group(1))
+                matches = re.findall(regex, response_text)
+                if matches:
+                    match = matches[-1]
+                    extracted_answer = normalize_extracted_answer(match)
                     break
             score = 1.0 if extracted_answer == row["Answer"] else 0.0
             html = common.jinja_env.from_string(HTML_JINJA).render(


### PR DESCRIPTION
# Description

This pull request addresses issue https://github.com/openai/simple-evals/issues/33 by fixing the regular expression used to extract answers from model outputs with MMLU.

# Solution

The existing regex fails to handle cases where the "Answer: LETTER" pattern appears multiple times. This is resolved by:
- Using `re.findall`: Instead of `re.search`, `re.findall` is used to find all occurrences of the answer pattern.
- Selecting the last match: The last match from the `re.findall` results is taken as the correct answer.
- Allowing overlapping matches: The regex pattern is adjusted to allow overlapping matches, using a [capturing group inside a lookahead](https://stackoverflow.com/a/5616910/12724988).