### PR TITLE
Add reasoning_effort param to O1ChatCompletionSampler

### DIFF
--- a/sampler/o1_chat_completion_sampler.py
+++ b/sampler/o1_chat_completion_sampler.py
@@ -6,6 +6,7 @@ from openai import OpenAI
 
 from ..types import MessageList, SamplerBase
 
+
 class O1ChatCompletionSampler(SamplerBase):
     """
     Sample from OpenAI's chat completion API for o1 models
@@ -13,6 +14,8 @@ class O1ChatCompletionSampler(SamplerBase):
 
     def __init__(
         self,
+        *,
+        reasoning_effort: str | None = None,
         model: str = "o1-mini",
     ):
         self.api_key_name = "OPENAI_API_KEY"
@@ -20,6 +23,7 @@ class O1ChatCompletionSampler(SamplerBase):
         # using api_key=os.environ.get("OPENAI_API_KEY")  # please set your API_KEY
         self.model = model
         self.image_format = "url"
+        self.reasoning_effort = reasoning_effort
 
     def _handle_image(
         self, image: str, encoding: str = "base64", format: str = "png", fovea: int = 768
@@ -45,6 +49,7 @@ class O1ChatCompletionSampler(SamplerBase):
                 response = self.client.chat.completions.create(
                     model=self.model,
                     messages=message_list,
+                    reasoning_effort=self.reasoning_effort,
                 )
                 return response.choices[0].message.content
             # NOTE: BadRequestError is triggered once for MMMU, please uncomment if you are reruning MMMU


### PR DESCRIPTION
Allows for evaling reasoning models across various reasoning effort options (see https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort)