### PR TITLE
fix regex bug in browsecomp

### DIFF
--- a/browsecomp_eval.py
+++ b/browsecomp_eval.py
@@ -89,7 +89,7 @@ class BrowseCompEval(Eval):
         grading_response = self.grader_model(prompt_messages)
 
         match = re.search(r"correct: (yes|no)", grading_response)
-        return match.group(0) if match else "no"  # Default to "no" if no match
+        return match.group(1) if match else "no"  # Default to "no" if no match
 
     def __call__(self, sampler: SamplerBase) -> EvalResult:
             def fn(row: dict):


### PR DESCRIPTION
match.group(0) captures "correct: yes/no" when we just want "yes" or "no" (without "correct:") , match.group(1) fixes this