### PR TITLE
Fix regex extraction for browse comp

### DIFF
--- a/browsecomp_eval.py
+++ b/browsecomp_eval.py
@@ -90,7 +90,7 @@ class BrowseCompEval(Eval):
         grading_response = sampler_response.response_text
 
         match = re.search(r"correct: (yes|no)", grading_response)
-        return match.group(0) if match else "no"  # Default to "no" if no match
+        return match.group(1) if match else "no"  # Default to "no" if no match
 
     def __call__(self, sampler: SamplerBase) -> EvalResult:
             def fn(row: dict):


### PR DESCRIPTION
Before:
```ipython
In [739]: re.search(r"correct: (yes|no)", "correct: yes").group(0)
Out[739]: 'correct: yes'
```
After:
```ipython
In [740]: re.search(r"correct: (yes|no)", "correct: yes").group(1)
Out[740]: 'yes'
```
I'm happy to add a unit test though I didn't see any. Also happy to add the calibration error metric, let me know if that's useful or not.