### PR TITLE
Add HealthBench Professional options

### DIFF
--- a/healthbench_eval.py
+++ b/healthbench_eval.py
@@ -154,6 +154,16 @@ def calculate_score(
     return overall_score
 
 
+def calculate_length_adjusted_score(
+    score: float,
+    response_text: str,
+    *,
+    center: float,
+    penalty_per_500_chars: float,
+) -> float:
+    return score - penalty_per_500_chars * ((len(response_text) - center) / 500.0)
+
+
 def get_usage_dict(response_usage) -> dict[str, int | None]:
     if response_usage is None:
         return {
@@ -273,7 +283,30 @@ class HealthBenchEval(Eval):
         run_reference_completions: bool = False,
         n_threads: int = 120,
         subset_name: Literal["hard", "consensus"] | None = None,
+        input_path: str | None = None,
+        length_adjustment_center: float | None = None,
+        length_adjustment_penalty_per_500_chars: float | None = None,
     ):
+        length_adjustment_enabled = (
+            length_adjustment_center is not None
+            or length_adjustment_penalty_per_500_chars is not None
+        )
+        if length_adjustment_enabled:
+            if (
+                length_adjustment_center is None
+                or length_adjustment_penalty_per_500_chars is None
+            ):
+                raise ValueError(
+                    "length_adjustment_center and "
+                    "length_adjustment_penalty_per_500_chars must be set together"
+                )
+            if length_adjustment_center < 0:
+                raise ValueError("length_adjustment_center must be non-negative")
+            if length_adjustment_penalty_per_500_chars < 0:
+                raise ValueError(
+                    "length_adjustment_penalty_per_500_chars must be non-negative"
+                )
+
         if run_reference_completions:
             assert physician_completions_mode is not None, (
                 "physician_completions_mode must be provided if run_reference_completions is True"
@@ -284,14 +317,18 @@ class HealthBenchEval(Eval):
                 "physician_completions_mode must have reference completions if run_reference_completions is True"
             )
 
-        if subset_name == "hard":
-            input_path = INPUT_PATH_HARD
-        elif subset_name == "consensus":
-            input_path = INPUT_PATH_CONSENSUS
-        elif subset_name is None:
-            input_path = INPUT_PATH
+        if input_path is None:
+            if subset_name == "hard":
+                input_path = INPUT_PATH_HARD
+            elif subset_name == "consensus":
+                input_path = INPUT_PATH_CONSENSUS
+            elif subset_name is None:
+                input_path = INPUT_PATH
+            else:
+                assert False, f"Invalid subset name: {subset_name}"
         else:
-            assert False, f"Invalid subset name: {subset_name}"
+            assert subset_name is None, "subset_name must be None when input_path is set"
+
         with bf.BlobFile(input_path, "rb") as f:
             examples = [json.loads(line) for line in f]
         for example in examples:
@@ -352,6 +389,10 @@ class HealthBenchEval(Eval):
         self.examples = examples * n_repeats
         self.n_threads = n_threads
         self.grader_model = grader_model
+        self.length_adjustment_center = length_adjustment_center
+        self.length_adjustment_penalty_per_500_chars = (
+            length_adjustment_penalty_per_500_chars
+        )
 
     def grade_sample(
         self,
@@ -394,6 +435,14 @@ class HealthBenchEval(Eval):
         metrics = {
             "overall_score": overall_score,
         }
+        if self.length_adjustment_center is not None:
+            assert self.length_adjustment_penalty_per_500_chars is not None
+            metrics["overall_score_length_adjusted"] = calculate_length_adjusted_score(
+                overall_score,
+                response_text,
+                center=self.length_adjustment_center,
+                penalty_per_500_chars=self.length_adjustment_penalty_per_500_chars,
+            )
 
         # compute scores for example-level tags)
         example_tag_scores = {tag: overall_score for tag in example_tags}

--- a/healthbench_eval_test.py
+++ b/healthbench_eval_test.py
@@ -1,4 +1,8 @@
-from .healthbench_eval import RubricItem, calculate_score
+from .healthbench_eval import (
+    RubricItem,
+    calculate_length_adjusted_score,
+    calculate_score,
+)
 
 
 def test_calculate_score():
@@ -20,6 +24,18 @@ def test_calculate_score():
         calculate_score(rubric_items, grading_response_list)
         == achieved / total_possible
     )
+
+
+def test_calculate_length_adjusted_score():
+    assert abs(
+        calculate_length_adjusted_score(
+            0.8,
+            "a" * 2500,
+            center=2000,
+            penalty_per_500_chars=0.022,
+        )
+        - 0.778
+    ) < 1e-12
 
 
 if __name__ == "__main__":

--- a/simple_evals.py
+++ b/simple_evals.py
@@ -59,8 +59,87 @@ def main():
     parser.add_argument(
         "--examples", type=int, help="Number of examples to use (overrides default)"
     )
+    parser.add_argument(
+        "--healthbench-input-path",
+        type=str,
+        default=None,
+        help=(
+            "Run the main HealthBench eval from a blobfile-readable JSONL path in "
+            "HealthBench format. This only applies to --eval=healthbench."
+        ),
+    )
+    parser.add_argument(
+        "--healthbench-professional-mode",
+        action="store_true",
+        help=(
+            "Require the HealthBench Professional option bundle: main HealthBench "
+            "custom input path, GPT-5.4 low grader, and length adjustment."
+        ),
+    )
+    parser.add_argument(
+        "--healthbench-use-gpt-5-4-low-grader",
+        action="store_true",
+        help="Use GPT-5.4 with low reasoning effort as the HealthBench rubric grader.",
+    )
+    parser.add_argument(
+        "--healthbench-length-adjustment-center",
+        type=float,
+        default=None,
+        help=(
+            "Center character count for HealthBench length adjustment. Must be set "
+            "together with --healthbench-length-adjustment-penalty-per-500-chars."
+        ),
+    )
+    parser.add_argument(
+        "--healthbench-length-adjustment-penalty-per-500-chars",
+        type=float,
+        default=None,
+        help=(
+            "Numerical score penalty per 500 response characters for HealthBench "
+            "length adjustment. Must be set together with "
+            "--healthbench-length-adjustment-center."
+        ),
+    )
 
     args = parser.parse_args()
+    if (
+        args.healthbench_input_path is not None
+        and args.eval is not None
+        and "healthbench" not in args.eval.split(",")
+    ):
+        parser.error(
+            "--healthbench-input-path only applies when --eval includes healthbench"
+        )
+    if (
+        args.healthbench_length_adjustment_center is None
+    ) != (args.healthbench_length_adjustment_penalty_per_500_chars is None):
+        parser.error(
+            "--healthbench-length-adjustment-center and "
+            "--healthbench-length-adjustment-penalty-per-500-chars must be set together"
+        )
+    if args.healthbench_professional_mode:
+        evals_requested = set(args.eval.split(",")) if args.eval is not None else set()
+        if evals_requested != {"healthbench"}:
+            parser.error(
+                "--healthbench-professional-mode requires --eval=healthbench"
+            )
+        if args.healthbench_input_path is None:
+            parser.error(
+                "--healthbench-professional-mode requires --healthbench-input-path"
+            )
+        if not args.healthbench_use_gpt_5_4_low_grader:
+            parser.error(
+                "--healthbench-professional-mode requires "
+                "--healthbench-use-gpt-5-4-low-grader"
+            )
+        if (
+            args.healthbench_length_adjustment_center is None
+            or args.healthbench_length_adjustment_penalty_per_500_chars is None
+        ):
+            parser.error(
+                "--healthbench-professional-mode requires both HealthBench length "
+                "adjustment flags"
+            )
 
     models = {
         # Reasoning Models
@@ -256,6 +335,15 @@ def main():
         system_message=OPENAI_SYSTEM_MESSAGE_API,
         max_tokens=2048,
     )
+    healthbench_grading_sampler = (
+        ResponsesSampler(
+            model="gpt-5.4-2026-03-05",
+            reasoning_model=True,
+            reasoning_effort="low",
+        )
+        if args.healthbench_use_gpt_5_4_low_grader
+        else grading_sampler
+    )
     equality_checker = ChatCompletionSampler(model="gpt-4-turbo-preview")
     # ^^^ used for fuzzy matching, just for math
 
@@ -301,27 +389,40 @@ def main():
                 )
             case "healthbench":
                 return HealthBenchEval(
-                    grader_model=grading_sampler,
+                    grader_model=healthbench_grading_sampler,
                     num_examples=10 if debug_mode else num_examples,
                     n_repeats=args.n_repeats or 1,
                     n_threads=args.n_threads or 1,
                     subset_name=None,
+                    input_path=args.healthbench_input_path,
+                    length_adjustment_center=args.healthbench_length_adjustment_center,
+                    length_adjustment_penalty_per_500_chars=(
+                        args.healthbench_length_adjustment_penalty_per_500_chars
+                    ),
                 )
             case "healthbench_hard":
                 return HealthBenchEval(
-                    grader_model=grading_sampler,
+                    grader_model=healthbench_grading_sampler,
                     num_examples=10 if debug_mode else num_examples,
                     n_repeats=args.n_repeats or 1,
                     n_threads=args.n_threads or 1,
                     subset_name="hard",
+                    length_adjustment_center=args.healthbench_length_adjustment_center,
+                    length_adjustment_penalty_per_500_chars=(
+                        args.healthbench_length_adjustment_penalty_per_500_chars
+                    ),
                 )
             case "healthbench_consensus":
                 return HealthBenchEval(
-                    grader_model=grading_sampler,
+                    grader_model=healthbench_grading_sampler,
                     num_examples=10 if debug_mode else num_examples,
                     n_repeats=args.n_repeats or 1,
                     n_threads=args.n_threads or 1,
                     subset_name="consensus",
+                    length_adjustment_center=args.healthbench_length_adjustment_center,
+                    length_adjustment_penalty_per_500_chars=(
+                        args.healthbench_length_adjustment_penalty_per_500_chars
+                    ),
                 )
             case "healthbench_meta":
                 return HealthBenchMetaEval(


### PR DESCRIPTION
Adds HealthBench-only support for:
- custom HealthBench-format input paths
- GPT-5.4 low reasoning effort as the HealthBench rubric grader
- length-adjusted HealthBench scoring
- a `--healthbench-professional-mode` guardrail that requires the full intended option bundle

Validation:
- `python -m py_compile simple_evals.py healthbench_eval.py healthbench_eval_test.py`
- `python -m simple-evals-pr848615.healthbench_eval_test`
- `python -m simple-evals-pr848615.simple_evals --help`
- argparse guardrail checks for invalid HealthBench flag combinations
- custom-input HealthBenchEval constructor smoke test
- `git diff --check`

Co-authored-by: Codex <noreply@openai.com>